### PR TITLE
chore : Label 컴포넌트 폴더화 및 스토리북 추가

### DIFF
--- a/src/components/label/Label.stories.tsx
+++ b/src/components/label/Label.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import Label from './Label'
+
+import testImage from '/public/next.svg'
+
+const meta: Meta<typeof Label> = {
+  title: 'Components/Label',
+  component: Label,
+  argTypes: {
+    children: { control: 'text' },
+    src: { control: 'text' },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Label>
+
+export const Default: Story = {
+  args: {
+    children: 'Default Label',
+  },
+}
+
+export const WithIcon: Story = {
+  args: {
+    children: 'Label with Icon',
+    src: testImage,
+  },
+}

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image'
 
-interface LabelProps {
+type Props = {
   children: React.ReactNode
   src?: string
 }
 
-const Label = ({ children, src }: LabelProps) => {
+const Label = ({ children, src }: Props) => {
   return (
     <div className="flex-align gap-2">
       {src && <Image src={src} width={28} height={28} alt="label-icon" />}

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -1,11 +1,11 @@
+import type { PropsWithChildren } from 'react'
 import Image from 'next/image'
 
-type Props = {
-  children: React.ReactNode
+type LabelProps = {
   src?: string
 }
 
-const Label = ({ children, src }: Props) => {
+const Label = ({ children, src }: PropsWithChildren<LabelProps>) => {
   return (
     <div className="flex-align gap-2">
       {src && <Image src={src} width={28} height={28} alt="label-icon" />}


### PR DESCRIPTION
## 변경 사항

- 폴더구조 규칙에 의해 Label 컴포넌트를 폴더화
- 스토리북 테스트 추가
- props 타입 변경

<br/>

## 리뷰 필요

`interface`가 아닌 `type`을 사용하는 것을 권유드립니다.

<br/>

첫 번째 이유는 type을 사용하면 함수의 타입을 더 명확하게 정의할 수 있습니다.
`type StringToNumber = (str: string) => number;`

<br/>

두 번째 이유는 유틸리티 타입들이 종종 사용될텐데 이때는 `type`을 사용해야만 합니다.
interface와 type의 혼용보다는 type만으로 일관성을 유지하기 위해서입니다.
```
type User = {
  id: string;
  name: string;
  age: number;
};

type PartialUser = Partial<User>;
```

<br/>

어떠한 방식이라도 하나의 컨벤션을 정해서 사용한다면 더 좋은 프로젝트가 될 것 같습니다. 
자유롭게 의견 남겨주세요 :)

<br/>

close #36 
