### PR TITLE
chore: chromatic deployment 워크플로우 수정

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - '**.stories.tsx'
 
+permissions:
+  pull-requests: write
+
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
@@ -18,6 +21,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Clean Yarn Cache
+        run: yarn cache clean --all
 
       - name: Install dependencies
         run: yarn install --immutable --check-cache

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,7 +9,3 @@ supportedArchitectures:
     - current
     - x64
     - arm64
-  libc:
-    - current
-    - glibc
-    - musl

--- a/src/components/label/Label.stories.tsx
+++ b/src/components/label/Label.stories.tsx
@@ -5,7 +5,7 @@ import Label from './Label'
 import testImage from '/public/next.svg'
 
 const meta: Meta<typeof Label> = {
-  title: 'Components/Label',
+  title: 'Label',
   component: Label,
   argTypes: {
     children: { control: 'text' },


### PR DESCRIPTION
## 변경 사항

- 워크플로우 내 의존성 설치 시에 메모리 할당 오류 해결
- `.yarnrc.yml` 내 supportedArchitectures libc 설정 제거
- chromatic deployment 워크플로우 내 PR에 코멘트를 추가하기 위한 권한 설정

## 리뷰 필요

- ~잘 동작할때까지 close/open 반복하면서 테스트 할 예정입니다. 테스트 이후에 merge 하겠습니다.~
- 앞으로는 스토리 파일이 변경되면 main, develop 브랜치에 PR, push 되었을 때 빌드 및 배포자동화가 되고 귀여운 댓글이 달립니다~!

### 첨부 링크(옵션)
- [Couldn't allocate enough memory 에러 관련 자료](https://github.com/yarnpkg/berry/issues/3972#issuecomment-2094664898)
  <img width="914" alt="image" src="https://github.com/user-attachments/assets/26e4a436-5e6a-44d7-8eac-a4a75197f0ea">


close #40
