### PR TITLE
fix : useToggle 훅에 'use client' 선언 추가

### DIFF
--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,3 +1,4 @@
+'use client'
 import { useState } from 'react'
 
 type UseToggleType = (initalState?: boolean) => [boolean, () => void]


### PR DESCRIPTION
#55

## 변경 사항

- useToggle 훅에서 'use client'를 선언하지 않아서 컴파일이 실패하는 오류를 발견했습니다.
- 이를 수정하여 올립니다.

close #55 
