### PR TITLE
feat: Header 컴포넌트 추가

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,6 +12,9 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    nextjs: {
+      appDirectory: true,
+    },
   },
   decorators: [
     (Story) => (

--- a/src/components/header/Header.stories.tsx
+++ b/src/components/header/Header.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { MainHeader } from './MainHeader'
+import { SubHeader } from './SubHeader'
+
+const meta: Meta<typeof SubHeader> = {
+  title: 'Header',
+  component: SubHeader,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof SubHeader>
+
+export const Default: Story = {
+  args: {
+    title: '헤더 텍스트',
+    canBack: true,
+  },
+}
+
+export const All = () => {
+  return (
+    <div className="flex-column gap-[20px]">
+      <SubHeader title="뒤로가기 아이콘 헤더" canBack />
+      <SubHeader title="닫기 아이콘 헤더" canClose onClose={[() => alert('닫기')]} />
+      <SubHeader
+        title="취소 + 완료 헤더"
+        canClose
+        onClose={[() => alert('취소'), () => alert('완료')]}
+        btnStyle="text"
+      />
+      <MainHeader title={`메인 헤더\n프로필 아이콘`} canClose onClose={[() => alert('프로필')]} />
+      <MainHeader
+        title={`메인 헤더\n취소 + 완료`}
+        canClose
+        onClose={[() => alert('취소'), () => alert('완료')]}
+        btnStyle="text"
+      />
+      <MainHeader
+        title={`메인 헤더\n뒤로가기 아이콘 + 수정 + 삭제`}
+        canBack
+        canClose
+        onClose={[() => alert('삭제'), () => alert('완료')]}
+        btnStyle="mixed"
+      />
+    </div>
+  )
+}

--- a/src/components/header/Header.stories.tsx
+++ b/src/components/header/Header.stories.tsx
@@ -5,7 +5,7 @@ import { SubHeader } from './SubHeader'
 
 const meta: Meta<typeof SubHeader.Back> = {
   title: 'Header',
-  component: SubHeader.Confirm,
+  component: SubHeader.Back,
   tags: ['autodocs'],
 }
 
@@ -22,20 +22,23 @@ export const Default: Story = {
 export const All = () => {
   return (
     <div className="flex-column gap-[20px]">
-      <MainHeader.Setting title={`메인 헤더\n프로필 아이콘`} onClose={[() => alert('프로필')]} />
+      <MainHeader.Setting title={`메인 헤더\n프로필 아이콘`} onSet={() => alert('마이페이지')} />
       <MainHeader.Confirm
         title={`메인 헤더\n취소 + 완료`}
-        onClose={[() => alert('취소'), () => alert('완료')]}
+        onCancel={() => alert('취소')}
+        onConfirm={() => alert('완료')}
       />
-      <MainHeader.BackAll
+      <MainHeader.Modify
         title={`메인 헤더\n뒤로가기 아이콘 + 수정 + 삭제`}
-        onClose={[() => alert('삭제'), () => alert('완료')]}
+        onDelete={() => alert('삭제')}
+        onModify={() => alert('수정')}
       />
       <SubHeader.Back title="뒤로가기 아이콘 헤더" />
-      <SubHeader.Close title="닫기 아이콘 헤더" onClose={[() => alert('닫기')]} />
+      <SubHeader.Close title="닫기 아이콘 헤더" onClose={() => alert('닫기')} />
       <SubHeader.Confirm
         title="취소 + 완료 헤더"
-        onClose={[() => alert('취소'), () => alert('완료')]}
+        onCancel={() => alert('취소')}
+        onConfirm={() => alert('완료')}
       />
     </div>
   )

--- a/src/components/header/Header.stories.tsx
+++ b/src/components/header/Header.stories.tsx
@@ -3,47 +3,39 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { MainHeader } from './MainHeader'
 import { SubHeader } from './SubHeader'
 
-const meta: Meta<typeof SubHeader> = {
+const meta: Meta<typeof SubHeader.Back> = {
   title: 'Header',
-  component: SubHeader,
+  component: SubHeader.Confirm,
   tags: ['autodocs'],
 }
 
 export default meta
 
-type Story = StoryObj<typeof SubHeader>
+type Story = StoryObj<typeof SubHeader.Back>
 
 export const Default: Story = {
   args: {
     title: '헤더 텍스트',
-    canBack: true,
   },
 }
 
 export const All = () => {
   return (
     <div className="flex-column gap-[20px]">
-      <SubHeader title="뒤로가기 아이콘 헤더" canBack />
-      <SubHeader title="닫기 아이콘 헤더" canClose onClose={[() => alert('닫기')]} />
-      <SubHeader
-        title="취소 + 완료 헤더"
-        canClose
-        onClose={[() => alert('취소'), () => alert('완료')]}
-        btnStyle="text"
-      />
-      <MainHeader title={`메인 헤더\n프로필 아이콘`} canClose onClose={[() => alert('프로필')]} />
-      <MainHeader
+      <MainHeader.Setting title={`메인 헤더\n프로필 아이콘`} onClose={[() => alert('프로필')]} />
+      <MainHeader.Confirm
         title={`메인 헤더\n취소 + 완료`}
-        canClose
         onClose={[() => alert('취소'), () => alert('완료')]}
-        btnStyle="text"
       />
-      <MainHeader
+      <MainHeader.BackAll
         title={`메인 헤더\n뒤로가기 아이콘 + 수정 + 삭제`}
-        canBack
-        canClose
         onClose={[() => alert('삭제'), () => alert('완료')]}
-        btnStyle="mixed"
+      />
+      <SubHeader.Back title="뒤로가기 아이콘 헤더" />
+      <SubHeader.Close title="닫기 아이콘 헤더" onClose={[() => alert('닫기')]} />
+      <SubHeader.Confirm
+        title="취소 + 완료 헤더"
+        onClose={[() => alert('취소'), () => alert('완료')]}
       />
     </div>
   )

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -7,25 +7,29 @@ import type { HeaderProps } from './SubHeader'
 
 const username = '가나다라' // 추후 useUserStore 로 변경 필요
 
-export const Setting = ({ title, onClose }: HeaderProps) => {
+export const Setting = ({ title, onSet }: Pick<HeaderProps, 'title' | 'onSet'>) => {
   return (
     <header className="flex-column-between h-[182px] bg-mint-3 px-[20px] pb-[24px] pt-[20px]">
       <div className="flex-align w-full justify-end">
-        <Profile name={username} size="sm" bgColor="#C5FDEC" onClickProfile={onClose?.[0]} />
+        <Profile name={username} size="sm" bgColor="#C5FDEC" onClickProfile={onSet} />
       </div>
       <h1 className="title-B whitespace-pre text-black">{title}</h1>
     </header>
   )
 }
 
-export const Confirm = ({ title, onClose }: HeaderProps) => {
+export const Confirm = ({
+  title,
+  onCancel,
+  onConfirm,
+}: Pick<HeaderProps, 'title' | 'onCancel' | 'onConfirm'>) => {
   return (
     <header className="flex-column-between h-[182px] bg-mint-3 px-[20px] pb-[24px] pt-[20px]">
       <div className="flex-between-align w-full">
-        <button className="body-B text-mint-7" onClick={onClose?.[0]}>
+        <button className="body-B text-mint-7" onClick={onCancel}>
           취소
         </button>
-        <button className="body-B text-mint-9" onClick={onClose?.[1]}>
+        <button className="body-B text-mint-9" onClick={onConfirm}>
           완료
         </button>
       </div>
@@ -34,7 +38,11 @@ export const Confirm = ({ title, onClose }: HeaderProps) => {
   )
 }
 
-export const BackAll = ({ title, onClose }: HeaderProps) => {
+export const Modify = ({
+  title,
+  onDelete,
+  onModify,
+}: Pick<HeaderProps, 'title' | 'onDelete' | 'onModify'>) => {
   const router = useRouter()
   const handleBack = () => {
     router.back()
@@ -47,11 +55,11 @@ export const BackAll = ({ title, onClose }: HeaderProps) => {
           <Icon name="arrow-left" />
         </button>
         <div className="flex-align gap-[16px]">
-          <button type="button" onClick={onClose?.[0]} className="body-B text-mint-7">
+          <button type="button" onClick={onDelete} className="body-B text-mint-7">
             삭제
           </button>
-          <button type="button" onClick={onClose?.[1]} className="body-B text-mint-9">
-            완료
+          <button type="button" onClick={onModify} className="body-B text-mint-9">
+            수정
           </button>
         </div>
       </div>
@@ -60,4 +68,4 @@ export const BackAll = ({ title, onClose }: HeaderProps) => {
   )
 }
 
-export const MainHeader = { Setting, Confirm, BackAll }
+export const MainHeader = { Setting, Confirm, Modify }

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -5,55 +5,59 @@ import { Profile } from '../profile/Profile'
 
 import type { HeaderProps } from './SubHeader'
 
-export const MainHeader = ({
-  title,
-  canBack,
-  canClose,
-  onClose,
-  btnStyle = 'icon',
-}: HeaderProps) => {
-  const router = useRouter()
-  const handleBack = () => {
-    router.back()
-  }
+const username = '가나다라' // 추후 useUserStore 로 변경 필요
 
-  const username = '가나다라' // 추후 useUserStore 로 변경 필요
-
-  const isIcon = btnStyle === 'icon'
-  const isMixed = btnStyle === 'mixed'
-
+export const Setting = ({ title, onClose }: HeaderProps) => {
   return (
     <header className="flex-column-between h-[182px] bg-mint-3 px-[20px] pb-[24px] pt-[20px]">
-      <div className="flex-between-align w-full">
-        {
-          <button
-            type="button"
-            onClick={isIcon || isMixed ? handleBack : onClose?.[0]}
-            className="body-B text-mint-7"
-          >
-            {canBack ? <Icon name="arrow-left" /> : !isIcon && '취소'}
-          </button>
-        }
-        {canClose && !isMixed ? (
-          <button
-            type="button"
-            onClick={isIcon ? onClose?.[0] : onClose?.[1]}
-            className="body-B text-mint-9"
-          >
-            {isIcon ? <Profile name={username} size="sm" bgColor="#C5FDEC" /> : '완료'}
-          </button>
-        ) : (
-          <div className="flex-align gap-[16px]">
-            <button type="button" onClick={onClose?.[0]} className="body-B text-mint-7">
-              삭제
-            </button>
-            <button type="button" onClick={onClose?.[1]} className="body-B text-mint-9">
-              완료
-            </button>
-          </div>
-        )}
+      <div className="flex-align w-full justify-end">
+        <Profile name={username} size="sm" bgColor="#C5FDEC" onClickProfile={onClose?.[0]} />
       </div>
       <h1 className="title-B whitespace-pre text-black">{title}</h1>
     </header>
   )
 }
+
+export const Confirm = ({ title, onClose }: HeaderProps) => {
+  return (
+    <header className="flex-column-between h-[182px] bg-mint-3 px-[20px] pb-[24px] pt-[20px]">
+      <div className="flex-between-align w-full">
+        <button className="body-B text-mint-7" onClick={onClose?.[0]}>
+          취소
+        </button>
+        <button className="body-B text-mint-9" onClick={onClose?.[1]}>
+          완료
+        </button>
+      </div>
+      <h1 className="title-B whitespace-pre text-black">{title}</h1>
+    </header>
+  )
+}
+
+export const BackAll = ({ title, onClose }: HeaderProps) => {
+  const router = useRouter()
+  const handleBack = () => {
+    router.back()
+  }
+
+  return (
+    <header className="flex-column-between h-[182px] bg-mint-3 px-[20px] pb-[24px] pt-[20px]">
+      <div className="flex-between-align w-full">
+        <button className="body-B text-mint-7" onClick={handleBack}>
+          <Icon name="arrow-left" />
+        </button>
+        <div className="flex-align gap-[16px]">
+          <button type="button" onClick={onClose?.[0]} className="body-B text-mint-7">
+            삭제
+          </button>
+          <button type="button" onClick={onClose?.[1]} className="body-B text-mint-9">
+            완료
+          </button>
+        </div>
+      </div>
+      <h1 className="title-B whitespace-pre text-black">{title}</h1>
+    </header>
+  )
+}
+
+export const MainHeader = { Setting, Confirm, BackAll }

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 
 import { Icon } from '../icons'
-import { Profile, Profile } from '../profile/Profile'
+import { Profile } from '../profile/Profile'
 
 import type { HeaderProps } from './SubHeader'
 

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 import { Icon } from '../icons'
 import { Profile } from '../profile/Profile'

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -1,0 +1,59 @@
+import { useRouter } from 'next/router'
+
+import { Icon } from '../icons'
+import { Profile, Profile } from '../profile/Profile'
+
+import type { HeaderProps } from './SubHeader'
+
+export const MainHeader = ({
+  title,
+  canBack,
+  canClose,
+  onClose,
+  btnStyle = 'icon',
+}: HeaderProps) => {
+  const router = useRouter()
+  const handleBack = () => {
+    router.back()
+  }
+
+  const username = '가나다라' // 추후 useUserStore 로 변경 필요
+
+  const isIcon = btnStyle === 'icon'
+  const isMixed = btnStyle === 'mixed'
+
+  return (
+    <header className="flex-column-between h-[182px] bg-mint-3 px-[20px] pb-[24px] pt-[20px]">
+      <div className="flex-between-align w-full">
+        {
+          <button
+            type="button"
+            onClick={isIcon || isMixed ? handleBack : onClose?.[0]}
+            className="body-B text-mint-7"
+          >
+            {canBack ? <Icon name="arrow-left" /> : !isIcon && '취소'}
+          </button>
+        }
+        {canClose && !isMixed ? (
+          <button
+            type="button"
+            onClick={isIcon ? onClose?.[0] : onClose?.[1]}
+            className="body-B text-mint-9"
+          >
+            {isIcon ? <Profile name={username} size="sm" bgColor="#C5FDEC" /> : '완료'}
+          </button>
+        ) : (
+          <div className="flex-align gap-[16px]">
+            <button type="button" onClick={onClose?.[0]} className="body-B text-mint-7">
+              삭제
+            </button>
+            <button type="button" onClick={onClose?.[1]} className="body-B text-mint-9">
+              완료
+            </button>
+          </div>
+        )}
+      </div>
+      <h1 className="title-B whitespace-pre text-black">{title}</h1>
+    </header>
+  )
+}

--- a/src/components/header/SubHeader.tsx
+++ b/src/components/header/SubHeader.tsx
@@ -4,47 +4,48 @@ import { Icon } from '../icons'
 
 export type HeaderProps = {
   title: string
-  canBack?: boolean
-  canClose?: boolean
   onClose?: VoidFunction[]
-  btnStyle?: 'icon' | 'text' | 'mixed'
 }
 
-export const SubHeader = ({
-  title,
-  canBack,
-  canClose,
-  onClose,
-  btnStyle = 'icon',
-}: HeaderProps) => {
+export const Back = ({ title }: HeaderProps) => {
   const router = useRouter()
   const handleBack = () => {
     router.back()
   }
 
-  const isIcon = btnStyle === 'icon'
-
   return (
     <header className="flex-between-align relative">
-      {
-        <button
-          type="button"
-          onClick={isIcon ? handleBack : onClose?.[0]}
-          className="body-B text-gray-6"
-        >
-          {canBack ? <Icon name="arrow-left" /> : !isIcon && '취소'}
-        </button>
-      }
+      <button onClick={handleBack}>
+        <Icon name="arrow-left" />
+      </button>
       <h1 className="subtitle-B absolute left-1/2 -translate-x-1/2 text-black">{title}</h1>
-      {canClose && (
-        <button
-          type="button"
-          onClick={isIcon ? onClose?.[0] : onClose?.[1]}
-          className="body-B text-black"
-        >
-          {isIcon ? <Icon name="close" /> : '완료'}
-        </button>
-      )}
     </header>
   )
 }
+
+export const Confirm = ({ title, onClose }: HeaderProps) => {
+  return (
+    <header className="flex-between-align relative">
+      <button className="body-B text-gray-6" onClick={onClose?.[0]}>
+        취소
+      </button>
+      <h1 className="subtitle-B absolute left-1/2 -translate-x-1/2 text-black">{title}</h1>
+      <button className="body-B text-black" onClick={onClose?.[1]}>
+        완료
+      </button>
+    </header>
+  )
+}
+
+export const Close = ({ title, onClose }: HeaderProps) => {
+  return (
+    <header className="flex-align relative justify-end">
+      <h1 className="subtitle-B absolute left-1/2 -translate-x-1/2 text-black">{title}</h1>
+      <button onClick={onClose?.[0]}>
+        <Icon name="close" />
+      </button>
+    </header>
+  )
+}
+
+export const SubHeader = { Back, Confirm, Close }

--- a/src/components/header/SubHeader.tsx
+++ b/src/components/header/SubHeader.tsx
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router'
+
+import { Icon } from '../icons'
+
+export type HeaderProps = {
+  title: string
+  canBack?: boolean
+  canClose?: boolean
+  onClose?: VoidFunction[]
+  btnStyle?: 'icon' | 'text' | 'mixed'
+}
+
+export const SubHeader = ({
+  title,
+  canBack,
+  canClose,
+  onClose,
+  btnStyle = 'icon',
+}: HeaderProps) => {
+  const router = useRouter()
+  const handleBack = () => {
+    router.back()
+  }
+
+  const isIcon = btnStyle === 'icon'
+
+  return (
+    <header className="flex-between-align relative">
+      {
+        <button
+          type="button"
+          onClick={isIcon ? handleBack : onClose?.[0]}
+          className="body-B text-gray-6"
+        >
+          {canBack ? <Icon name="arrow-left" /> : !isIcon && '취소'}
+        </button>
+      }
+      <h1 className="subtitle-B absolute left-1/2 -translate-x-1/2 text-black">{title}</h1>
+      {canClose && (
+        <button
+          type="button"
+          onClick={isIcon ? onClose?.[0] : onClose?.[1]}
+          className="body-B text-black"
+        >
+          {isIcon ? <Icon name="close" /> : '완료'}
+        </button>
+      )}
+    </header>
+  )
+}

--- a/src/components/header/SubHeader.tsx
+++ b/src/components/header/SubHeader.tsx
@@ -4,10 +4,15 @@ import { Icon } from '../icons'
 
 export type HeaderProps = {
   title: string
-  onClose?: VoidFunction[]
+  onClose: VoidFunction
+  onCancel: VoidFunction
+  onConfirm: VoidFunction
+  onSet: VoidFunction
+  onDelete: VoidFunction
+  onModify: VoidFunction
 }
 
-export const Back = ({ title }: HeaderProps) => {
+export const Back = ({ title }: Pick<HeaderProps, 'title'>) => {
   const router = useRouter()
   const handleBack = () => {
     router.back()
@@ -23,26 +28,30 @@ export const Back = ({ title }: HeaderProps) => {
   )
 }
 
-export const Confirm = ({ title, onClose }: HeaderProps) => {
+export const Close = ({ title, onClose }: Pick<HeaderProps, 'title' | 'onClose'>) => {
   return (
-    <header className="flex-between-align relative">
-      <button className="body-B text-gray-6" onClick={onClose?.[0]}>
-        취소
-      </button>
+    <header className="flex-align relative justify-end">
       <h1 className="subtitle-B absolute left-1/2 -translate-x-1/2 text-black">{title}</h1>
-      <button className="body-B text-black" onClick={onClose?.[1]}>
-        완료
+      <button onClick={onClose}>
+        <Icon name="close" />
       </button>
     </header>
   )
 }
 
-export const Close = ({ title, onClose }: HeaderProps) => {
+export const Confirm = ({
+  title,
+  onCancel,
+  onConfirm,
+}: Pick<HeaderProps, 'title' | 'onCancel' | 'onConfirm'>) => {
   return (
-    <header className="flex-align relative justify-end">
+    <header className="flex-between-align relative">
+      <button className="body-B text-gray-6" onClick={onCancel}>
+        취소
+      </button>
       <h1 className="subtitle-B absolute left-1/2 -translate-x-1/2 text-black">{title}</h1>
-      <button onClick={onClose?.[0]}>
-        <Icon name="close" />
+      <button className="body-B text-black" onClick={onConfirm}>
+        완료
       </button>
     </header>
   )

--- a/src/components/header/SubHeader.tsx
+++ b/src/components/header/SubHeader.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 import { Icon } from '../icons'
 


### PR DESCRIPTION
## 변경 사항

- SubHeader 컴포넌트(Back, Close, Confirm) 추가
- MainHeader 컴포넌트(Setting, Confirm, Modify) 추가
- Header 컴포넌트 스토리 추가
- 스토리북 nextjs 앱라우터 설정

## 리뷰 필요

- SubHeader, MainHeader는 dot(.) 연산자로 각각 3가지 종류를 접근해서 사용 가능합니다. 자세한 사용법은 스토리북 참고 부탁드립니다!


제가 놓친 부분이 있으면 말씀 부탁드립니다!

### 첨부 링크(옵션)
<img width="413" alt="image" src="https://github.com/user-attachments/assets/7f851912-86ad-4996-bb44-e369e98bb432">

- [스토리북 설정 참고자료](https://storybook.js.org/blog/integrate-nextjs-and-storybook-automatically/)


close #51 
