### PR TITLE
feat: DashBoardTemplate 개발 (#103)

### DIFF
--- a/src/features/DashBoardTemplate.tsx
+++ b/src/features/DashBoardTemplate.tsx
@@ -1,0 +1,30 @@
+'use client' // 추후 삭제 예정
+import type { PropsWithChildren } from 'react'
+
+import { BottomNav } from '@/components'
+import { MainHeader } from '@/components/header/MainHeader'
+
+type DashBoardTemplateProps = {
+  route: 'health' | 'home' | 'medicine'
+}
+
+const HeaderTitle = {
+  health: '님의\n최근체중 변화',
+  home: '님의\n최근 건강 정보를 모아봤어요',
+  medicine: '님의\n최근 체중 변화',
+}
+
+export const DashBoardTemplate = ({
+  children,
+  route,
+}: PropsWithChildren<DashBoardTemplateProps>) => {
+  return (
+    <div className="flex h-full flex-col">
+      <MainHeader.Setting title={HeaderTitle[route]} />
+      <div className="flex-column flex-1 items-center overflow-y-auto px-5 pb-[107px] pt-8 scrollbar-hide">
+        {children}
+      </div>
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,0 +1,1 @@
+export * from './DashBoardTemplate'


### PR DESCRIPTION
## 변경 사항
- 공통적으로 사용되는 Header BottomNav 그리고 그 사이에 존재하는 Content UI의 재사용성을 높이기 위해 템플릿을 개발했습니다.
- feature 배럴파일 생성

<img width="183" alt="스크린샷 2024-09-04 오후 4 21 21" src="https://github.com/user-attachments/assets/7a00e0f2-0822-4043-9cdc-e9f6ed88d663">
<img width="190" alt="스크린샷 2024-09-04 오후 4 21 37" src="https://github.com/user-attachments/assets/c4a92a8e-2517-4984-920f-ff254bf69303">
<img width="185" alt="스크린샷 2024-09-04 오후 4 21 48" src="https://github.com/user-attachments/assets/0c5e95dd-1c03-4385-a054-4c299f173d97">

추가적으로
현재 템플릿에 use client를 사용했는데
MainHeader에서 use client를 사용했음에도 불구하고 적용이 안 되는 문제가 있었습니다.

```ts
<MainHeader.Setting title={HeaderTitle[route]} />
```
https://medium.com/@fdikmen/fixing-could-not-find-the-module-error-in-nextjs-with-ant-design-3ae2cfe0160d

추후 다음과 같이 변경한 후 use client를 제거하면 좋을거 같습니다

## 리뷰 필요

- 배럴
- 템플릿

close #103 
