### PR TITLE
refactor : TextWithArrow 클릭 범위 수정

### DIFF
--- a/src/components/inputGroup/TextWithArrow.tsx
+++ b/src/components/inputGroup/TextWithArrow.tsx
@@ -9,20 +9,19 @@ type TextWithArrowProps = {
 }
 
 export const TextWithArrow = ({ isLong = false, section, onClick }: TextWithArrowProps) => {
-  const { register } = useFormContext()
+  const { getValues, register } = useFormContext()
   const layoutStyle = isLong ? 'flex-between-align' : 'flex-align gap-1'
   const fontStyle = isLong ? 'body-M text-gray-6' : 'text-right headline-M text-gray-7'
 
   return (
-    <div className={layoutStyle}>
+    <button type="button" className={`${layoutStyle} cursor-pointer`} onClick={onClick}>
       <input
-        className={`max-w-[180px] ${fontStyle} disabled:bg-transparent`}
+        className={`${fontStyle} cursor-pointer focus:outline-none disabled:bg-transparent`}
+        size={getValues(section).length}
         {...register(section)}
-        disabled
+        readOnly
       />
-      <button type="button" onClick={onClick}>
-        <Icon size={28} name="arrow-right" />
-      </button>
-    </div>
+      <Icon size={28} name="arrow-right" />
+    </button>
   )
 }


### PR DESCRIPTION
## 변경 사항

- TextWithArrow 의 클릭 범위를 수정하였습니다.

## 리뷰 필요

- 작은 사이즈의 경우 input의 크기를 내부 글자의 크기만큼으로 지정하였습니다. 해당 부분만 클릭 가능합니다.
- 큰 사이즈의 경우 화면에 꽉차는 범위만큼 클릭 가능합니다.

close #118 
