### PR TITLE
refactor : slider 초기값 설정 액션 추가

### DIFF
--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -30,8 +30,7 @@ export const Slider = ({ list, initialSlide, onChange }: SliderProps) => {
 
   const handleSlideChange = useCallback(
     ({ realIndex }: { realIndex: number }) => {
-      const currentIndex = (realIndex + 2) % list.length
-      activeIndexRef.current = currentIndex
+      activeIndexRef.current = realIndex
       debouncedSlideChange()
     },
     [debouncedSlideChange, list.length],
@@ -41,9 +40,10 @@ export const Slider = ({ list, initialSlide, onChange }: SliderProps) => {
     <Swiper
       spaceBetween={0}
       slidesPerView={5}
+      centeredSlides={true}
       direction="vertical"
       loop={true}
-      initialSlide={parseInt(initialSlide) - 2}
+      initialSlide={parseInt(initialSlide)}
       className="headline-M h-[150px] w-6 text-center"
       onSlideChange={handleSlideChange}
     >

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -7,6 +7,7 @@ import 'swiper/css'
 
 type SliderProps = {
   list: readonly string[]
+  initialSlide: string
   onChange: (selected: number) => void
 }
 
@@ -20,7 +21,7 @@ const MemoizedSwiperSlide = memo(({ content }: MemoizedSwiperSlideProps) => {
 
 MemoizedSwiperSlide.displayName = 'MemoizedSwiperSlide'
 
-export const Slider = ({ list, onChange }: SliderProps) => {
+export const Slider = ({ list, initialSlide, onChange }: SliderProps) => {
   const activeIndexRef = useRef(0)
 
   const debouncedSlideChange = useDebounceCallback(() => {
@@ -42,7 +43,7 @@ export const Slider = ({ list, onChange }: SliderProps) => {
       slidesPerView={5}
       direction="vertical"
       loop={true}
-      initialSlide={list.length / 2 - 2}
+      initialSlide={parseInt(initialSlide) - 2}
       className="headline-M h-[150px] w-6 text-center"
       onSlideChange={handleSlideChange}
     >

--- a/src/components/slider/TimeSlider.tsx
+++ b/src/components/slider/TimeSlider.tsx
@@ -1,19 +1,23 @@
 'use client'
 import { HOURS, MINUTES } from '@/constants'
-import { useSelectedTimeActions } from '@/store/timeStore'
+import { useSelectedTime, useSelectedTimeActions } from '@/store/timeStore'
 
 import { Slider } from './Slider'
 
 export const TimeSlider = () => {
+  const time = useSelectedTime()
   const { handleHourChange, handleMinuteChange } = useSelectedTimeActions()
+
+  const hour = time.slice(0, 2)
+  const minute = time.slice(3, 5)
 
   return (
     <div className="flex-center relative w-full select-none rounded-xl bg-mint-0 py-[17px]">
       <div className="absolute top-1/2 h-[30px] w-[192px] -translate-y-1/2 rounded-lg bg-mint-2" />
       <div className="flex gap-8">
-        <Slider list={HOURS} onChange={handleHourChange} />
+        <Slider list={HOURS} initialSlide={hour} onChange={handleHourChange} />
         <p className="h-[30px] translate-y-[60px] leading-[30px]">:</p>
-        <Slider list={MINUTES} onChange={handleMinuteChange} />
+        <Slider list={MINUTES} initialSlide={minute} onChange={handleMinuteChange} />
       </div>
     </div>
   )

--- a/src/components/slider/WeightSlider.tsx
+++ b/src/components/slider/WeightSlider.tsx
@@ -1,21 +1,40 @@
 'use client'
 import { WEIGHT_NUMBERS } from '@/constants'
-import { useSelectedWeightActions } from '@/store/weightStore'
+import { useSelectedWeight, useSelectedWeightActions } from '@/store/weightStore'
 
 import { Slider } from './Slider'
 
 export const WeightSlider = () => {
   const { handleDecimalWeightChange, handleOnesWeightChange, handleTensWeightChange } =
     useSelectedWeightActions()
+  const weight = useSelectedWeight()
+
+  const tensOfWeight = weight.slice(0, 1)
+  const onesOfWeight = weight.slice(1, 2)
+  const decimalOfWeight = weight.slice(3, 4)
+
+  console.log(weight, tensOfWeight, onesOfWeight, decimalOfWeight)
 
   return (
     <div className="flex-center relative w-full select-none rounded-xl bg-mint-0 py-[17px]">
       <div className="headline-M absolute top-1/2 h-[30px] w-[158px] -translate-x-6 -translate-y-1/2 rounded-lg bg-mint-2" />
       <div className="flex gap-[14px]">
-        <Slider list={WEIGHT_NUMBERS} onChange={handleTensWeightChange} />
-        <Slider list={WEIGHT_NUMBERS} onChange={handleOnesWeightChange} />
+        <Slider
+          list={WEIGHT_NUMBERS}
+          initialSlide={tensOfWeight}
+          onChange={handleTensWeightChange}
+        />
+        <Slider
+          list={WEIGHT_NUMBERS}
+          initialSlide={onesOfWeight}
+          onChange={handleOnesWeightChange}
+        />
         <p className="h-[30px] translate-y-[65px]">.</p>
-        <Slider list={WEIGHT_NUMBERS} onChange={handleDecimalWeightChange} />
+        <Slider
+          list={WEIGHT_NUMBERS}
+          initialSlide={decimalOfWeight}
+          onChange={handleDecimalWeightChange}
+        />
         <p className="ml-3 h-[30px] translate-y-[64px]">Kg</p>
       </div>
     </div>

--- a/src/store/timeStore.ts
+++ b/src/store/timeStore.ts
@@ -3,6 +3,8 @@ import { create } from 'zustand'
 type Actions = {
   handleHourChange: (newHour: number) => void
   handleMinuteChange: (newMinute: number) => void
+  setInitialSelectedTime: (newTime: string) => void
+  resetSelectedTime: VoidFunction
 }
 
 type SelectedTimeStore = {
@@ -10,7 +12,7 @@ type SelectedTimeStore = {
   actions: Actions
 }
 
-const initialSelectedTime = '00:00:00'
+const initialSelectedTime = '12:30:00'
 
 export const useSelectedTimeStore = create<SelectedTimeStore>((set) => ({
   selectedTime: initialSelectedTime,
@@ -31,6 +33,8 @@ export const useSelectedTimeStore = create<SelectedTimeStore>((set) => ({
           selectedTime: `${hours}:${formattedMinute}:${seconds}`,
         }
       }),
+    setInitialSelectedTime: (newTime) => set(() => ({ selectedTime: newTime })),
+    resetSelectedTime: () => set(() => ({ selectedTime: initialSelectedTime })),
   },
 }))
 

--- a/src/store/weightStore.ts
+++ b/src/store/weightStore.ts
@@ -4,35 +4,42 @@ type Actions = {
   handleTensWeightChange: (newTens: number) => void
   handleOnesWeightChange: (newOnes: number) => void
   handleDecimalWeightChange: (newDecimal: number) => void
+  setInitialWeight: (newWeight: string) => void
+  resetWeight: VoidFunction
 }
 
 type SelectedWeightStore = {
-  weight: number
+  weight: string
   actions: Actions
 }
 
-const initialSelectedWeight = 0.0
+const initialSelectedWeight = '50.0'
 
 export const useSelectedWeightStore = create<SelectedWeightStore>((set) => ({
   weight: initialSelectedWeight,
   actions: {
     handleTensWeightChange: (newTens) =>
       set((state) => {
-        const currentIntegerPart = Math.floor(state.weight)
-        const newWeight = newTens * 10 + (currentIntegerPart % 10) + (state.weight % 1)
-        return { weight: parseFloat(newWeight.toFixed(1)) }
+        const [integerPart, decimalPart] = state.weight.split('.')
+        const ones = integerPart.slice(1)
+        const newWeight = `${newTens}${ones}.${decimalPart}`
+        return { weight: newWeight }
       }),
     handleOnesWeightChange: (newOnes) =>
       set((state) => {
-        const currentIntegerPart = Math.floor(state.weight)
-        const newWeight = Math.floor(currentIntegerPart / 10) * 10 + newOnes + (state.weight % 1)
-        return { weight: parseFloat(newWeight.toFixed(1)) }
+        const [integerPart, decimalPart] = state.weight.split('.')
+        const tens = integerPart.slice(0, 1)
+        const newWeight = `${tens}${newOnes}.${decimalPart}`
+        return { weight: newWeight }
       }),
     handleDecimalWeightChange: (newDecimal) =>
       set((state) => {
-        const newWeight = Math.floor(state.weight) + newDecimal / 10
-        return { weight: parseFloat(newWeight.toFixed(1)) }
+        const [integerPart] = state.weight.split('.')
+        const newWeight = `${integerPart}.${newDecimal}`
+        return { weight: newWeight }
       }),
+    setInitialWeight: (newWeight) => set(() => ({ weight: newWeight })),
+    resetWeight: () => set(() => ({ weight: initialSelectedWeight })),
   },
 }))
 


### PR DESCRIPTION
## 변경 사항

- TimeSlider와 WeightSlider 각각에 초기값 설정 가능하도록 액션을 설정하였습니다.
- WeightSlider의 변경 사항은 개념은 변하지 않았고, weight를 number로 처리하던 액션들을 string 으로 계산하는 방식으로 바뀌었습니다.

<br/>

- slider에 인덱스를 직접 계산하는 것이 아닌
```javascript
    <Swiper
      spaceBetween={0}
      slidesPerView={5}
      centeredSlides={true} // 이 부분
      direction="vertical"
      loop={true}
      initialSlide={parseInt(initialSlide)}
      className="headline-M h-[150px] w-6 text-center"
      onSlideChange={handleSlideChange}
    >
```
가운데 값을 인덱스로 설정하는 법을 찾아서 적용하게 되었습니다.

<br/>

#### 🐽 초기화 방법
아마 바텀시트에서 모두 사용될텐데요,
각각의 바텀시트가 처음 렌더링 될 때, `resetSelectedTime / resetWeight`를 호출하여 현재 입력된 값을 모두 초기화시킵니다.

만약 데이터로 받아온 값으로 초기화를 하고싶다면,
`setInitialSelectedTime / setInitialWeight`를 통하여 초기화를 시키면 됩니다.

기본값으로는 `12:30:00 / 50.0` 이 각각 설정되어있습니다.


close #120 
