### PR TITLE
fix : 진료페이지 알람 부분 버튼 type 지정

### DIFF
--- a/src/features/clinic/ui/ClinicCreateClientPage.tsx
+++ b/src/features/clinic/ui/ClinicCreateClientPage.tsx
@@ -79,6 +79,7 @@ export const ClinicCreateClientPage = () => {
           <InputGroup>
             <Label icon="time-label">알람</Label>
             <button
+              type="button"
               className="flex-between-align w-full rounded-xl border border-mint-3 py-4 pl-5 pr-4"
               onClick={toggleAlarmSheet}
             >


### PR DESCRIPTION
## 변경 사항

- 알람 부분 버튼 type 지정
버튼의 type을 지정하지 않아, 클릭 시에 폼이 제출되는 현상이 있었습니다.
type을 지정하여 해결하였습니다.

close #132 
